### PR TITLE
Fix $isNew to be aware of $idAttribute

### DIFF
--- a/src/angular-activerecord.js
+++ b/src/angular-activerecord.js
@@ -110,15 +110,15 @@ angular.module('ActiveRecord', ['ng']).factory('ActiveRecord', function($http, $
 		 * @return $q.promise
 		 */
 		$destroy: function (options) {
-			var defer = $q.defer();
+			var deferred = $q.defer();
 			if (this.$isNew()) {
-				defer.resolve();
-				return defer;
+				deferred.resolve();
+				return deferred.promise;
 			}
 			this.$sync('delete', this, options).then(function () {
-				defer.resolve();
-			}, defer.reject);
-			return defer;
+				deferred.resolve();
+			}, deferred.reject);
+			return deferred.promise;
 		},
 
 		/**

--- a/test/ActiveRecordSpec.js
+++ b/test/ActiveRecordSpec.js
@@ -88,7 +88,9 @@ describe("ActiveRecord", function() {
 		$httpBackend.expectDELETE('/resources/1').respond('');
 		var model = createBasicModel();
 		model.id = 1;
-		model.$destroy();
+		model.$destroy().then(function(){
+			// no expectations
+		});
 		$httpBackend.flush();
 	});
 


### PR DESCRIPTION
Currently if one uses `$idAttribute` other than `id` and tries to save model, the request will be `POST` not `PUT` because of `$isNew()` returning `true`. This PR fixes the emptiness check for model's id.
