### PR TITLE
Path to main missing in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
 	"name": "angular-activerecord",
 	"description": "A Backbone.Model inspired modellayer for AngularJS",
 	"version": "0.2.0",
+	"main": "src/angular-activerecord.js",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/bfanger/angular-activerecord.git"


### PR DESCRIPTION
After attempting to `grunt bower-install` this component, I received the following error:

> angular-activerecord was not injected in your file.
> Please go take a look in "app/bower_components/angular-activerecord" for the file you need, then manually include it in your file.

Adding `"main": "src/angular-activerecord.js"` to the `.bower.json` file allows the component to install properly. This pull request updates the `bower.json` file, from which `.bower.json` is generated, to include this value.
