### PR TITLE
$beforeSave & $afterSave: perform logic before and after $save method

### DIFF
--- a/src/angular-activerecord.js
+++ b/src/angular-activerecord.js
@@ -220,7 +220,7 @@ angular.module('ActiveRecord', []).factory('ActiveRecord', ['$http', '$q', '$par
 				var afterSave = this.$afterSave;
 			}
 
-			return this.$sync(operation, this, options).then(function (response) {
+			return this.$sync(operation, this, options).success(function (response, status) {
 				var data = model.$parse(response.data, options);
 				if (angular.isObject(data)) {
 					applyFilters(_result(model, '$readFilters'), data);
@@ -229,9 +229,11 @@ angular.module('ActiveRecord', []).factory('ActiveRecord', ['$http', '$q', '$par
 						return data;
 					};
 				}
-				if(afterSave) afterSave(response);
+				if(afterSave) afterSave(response, status);
 
 				return model;
+			}).error(function (response, status) {
+				if(afterSave) afterSave(response, status);
 			});
 		},
 


### PR DESCRIPTION
Loving ActiveRecord so far! It's usually my defacto solution for modelling with REST api's. 

The reason for this pull request is, I ran into a lot of code duplication of behaviour in controllers while working on a very large app. Which could easily be in one place: the model. 
Let's say you would like to show one and the same modal every time when an activerecord model fails to save. Just implement the  $afterSave method and on certain error codes just call the modalService and you're good to go.

If something needs to be refactored or elaborated about please let me know.

Rene